### PR TITLE
enforce strong typing in local modules imports

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [ignore]
-
+.*/lib/*.
 [include]
 
 [libs]
@@ -7,5 +7,6 @@
 [lints]
 
 [options]
-
+module.name_mapper='^utils\(.*\)$' -> '<PROJECT_ROOT>/server/src/utils/\1'
+module.name_mapper='^sockets\(.*\)$' -> '<PROJECT_ROOT>/server/src/sockets/\1'
 [strict]


### PR DESCRIPTION
Fixed bug #19 

We can still import the local modules like `require(utils/roomUtils);`  but flow will ignore the files under `/lib`.

![bug1](https://user-images.githubusercontent.com/40135286/115487489-6b6dab00-a21e-11eb-99c8-50e63ba03715.png)
