### PR TITLE
join room basic testing added

### DIFF
--- a/client/src/components/JoinRoom.js
+++ b/client/src/components/JoinRoom.js
@@ -37,12 +37,14 @@ function JoinRoom(): React$Element<any> {
       <div>
         <input 
           type='text' 
+          data-testid="username"
           placeholder='User Name'
           value={username}
           onChange={e => setUsername(e.target.value)}
         /><br/>
         <input 
           type='text'
+          data-testid="roomid"
           placeholder='Room id'
           value={roomId}
           onChange={e => setRoomId(e.target.value)}

--- a/client/src/components/__mocks__/ElementWithProviders.js
+++ b/client/src/components/__mocks__/ElementWithProviders.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react';
+import SocketContext from 'contexts/SocketContext';
+import UserContext from 'contexts/UserContext';
+import type { UserT } from 'common/types';
+import MockedProvider from 'providers/__mocks__/MockedProvider';
+
+type ElementWithProvidersT = {|
+  ui: React$Element<any>,
+  mockUserState: { user: ?UserT, setUser: mixed },
+  socket: Object,
+|};
+
+function ElementWithProviders (
+  props: ElementWithProvidersT
+): React$Element<any> {
+  return (
+    <MockedProvider value={props.mockUserState} context={UserContext}>
+      <MockedProvider value={props.socket} context={SocketContext}>
+        {props.ui}
+      </MockedProvider>
+    </MockedProvider>
+  );
+}
+
+export default ElementWithProviders;

--- a/client/src/components/__tests__/CreateRoom.test.js
+++ b/client/src/components/__tests__/CreateRoom.test.js
@@ -11,28 +11,12 @@ import {
 } from '@jest/globals';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history'
-import MockedProvider from 'providers/__mocks__/MockedProvider';
-import SocketContext from 'contexts/SocketContext';
-import UserContext from 'contexts/UserContext';
 import CreateRoom from '../CreateRoom';
 import io, { serverSocket, cleanSocket } from 'utils/__mocks__/MockedSocketIO';
+import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
 import type { UserT, RoomT, CreateRoomRequestT } from 'common/types';
 
 import '@testing-library/jest-dom';
-
-const customRender = (
-  ui: React$Element<any>,
-  mockUserState: { user: ?UserT, setUser: mixed },
-  socket: Object,
-): React$Element<any> => {
-  return render(
-    <MockedProvider value={mockUserState} context={UserContext}>
-      <MockedProvider value={socket} context={SocketContext}>
-        {ui}
-      </MockedProvider>
-    </MockedProvider>
-  );
-}
 
 describe('CreateRoom component', (): void => {
 
@@ -55,7 +39,13 @@ describe('CreateRoom component', (): void => {
   });
 
   test('CreateRoom renders wihtout crashing', (): void => {
-    customRender(<CreateRoom />, mockedUserState(), socket);
+    render(
+      <ElementWithProviders 
+        ui={<CreateRoom />}
+        mockUserState={mockedUserState()}
+        socket={socket}
+      />
+    );
     expect(
       screen.getByRole(
         'button', 
@@ -65,7 +55,13 @@ describe('CreateRoom component', (): void => {
   });
 
   test('create room button disabled if not username', (): void => {
-    customRender(<CreateRoom />, mockedUserState(), socket);
+    render(
+      <ElementWithProviders 
+        ui={<CreateRoom />}
+        mockUserState={mockedUserState()}
+        socket={socket}
+      />
+    );
     expect(
       screen.getByRole(
         'button', 
@@ -76,7 +72,13 @@ describe('CreateRoom component', (): void => {
 
 
   test('create room button enabled if username', (): void => {
-    customRender(<CreateRoom />, mockedUserState(), socket);
+    render(
+      <ElementWithProviders 
+        ui={<CreateRoom />}
+        mockUserState={mockedUserState()}
+        socket={socket}
+      />
+    );
     const userNameInput = screen.getByRole('textbox', {type: 'text'});
     fireEvent.change(userNameInput, { target: { value: 'a' } });
     expect(
@@ -116,7 +118,13 @@ describe('CreateRoom component', (): void => {
           <CreateRoom />
         </Router>
       );
-      customRender(ui, mockedUserState(), socket);
+      render(
+        <ElementWithProviders 
+          ui={ui}
+          mockUserState={mockedUserState()}
+          socket={socket}
+        />
+      );
       const userNameInput = screen.getByRole('textbox', {type: 'text'});
       const button = screen.getByRole('button', { name: /Create Room/i });
       fireEvent.change(userNameInput, { target: { value: username } });

--- a/client/src/components/__tests__/CreateRoom.test.js
+++ b/client/src/components/__tests__/CreateRoom.test.js
@@ -117,6 +117,7 @@ describe('CreateRoom component', (): void => {
     fireEvent.change(userNameInput, { target: { value: username } });
     expect(button).toBeEnabled();
     fireEvent.click(button);
+    expect(socket.has('joined-room')).toBe(true);
   });
 
 });

--- a/client/src/components/__tests__/CreateRoom.test.js
+++ b/client/src/components/__tests__/CreateRoom.test.js
@@ -87,37 +87,43 @@ describe('CreateRoom component', (): void => {
     ).toBeEnabled();
   });
 
-  test('create and join room sockets test', (): void => {
-    const username = 'owner';
-    let fakeRoom: RoomT = {
-      id: 'my-id',
-      users: [ ],
-      owner: '',
-      round: 1,
-      time: 30,
-    };
-    socket.on('create-room', (data: CreateRoomRequestT) => {
-      fakeRoom.users = [data.username];
-      fakeRoom.owner = data.username;
-      serverSocket.emit('joined-room', fakeRoom);
-    });
-    socket.on('joined-room', (room: RoomT) => {
-      expect(room).toBe(fakeRoom);
-      expect(room.owner).toBe(username);
-    });
-    const history = createMemoryHistory();
-    const ui = (
-      <Router history={history}>
-        <CreateRoom />
-      </Router>
-    );
-    customRender(ui, mockedUserState(), socket);
-    const userNameInput = screen.getByRole('textbox', {type: 'text'});
-    const button = screen.getByRole('button', { name: /Create Room/i });
-    fireEvent.change(userNameInput, { target: { value: username } });
-    expect(button).toBeEnabled();
-    fireEvent.click(button);
-    expect(socket.has('joined-room')).toBe(true);
-  });
+  test(
+    'when we click on create room button, we expect to received the joined ' +
+    'room response, everything should be alright.', 
+    (): void => {
+      const username = 'owner';
+      let fakeRoom: RoomT = {
+        id: 'my-id',
+        users: [ ],
+        owner: '',
+        round: 1,
+        time: 30,
+      };
+      // mock of what the server should do. 
+      socket.on('create-room', (data: CreateRoomRequestT) => {
+        fakeRoom.users = [data.username];
+        fakeRoom.owner = data.username;
+        serverSocket.emit('joined-room', fakeRoom);
+      });
+      // still check if the username that created the room is the same
+      socket.on('joined-room', (room: RoomT) => {
+        expect(room).toBe(fakeRoom);
+        expect(room.owner).toBe(username);
+      });
+      const history = createMemoryHistory();
+      const ui = (
+        <Router history={history}>
+          <CreateRoom />
+        </Router>
+      );
+      customRender(ui, mockedUserState(), socket);
+      const userNameInput = screen.getByRole('textbox', {type: 'text'});
+      const button = screen.getByRole('button', { name: /Create Room/i });
+      fireEvent.change(userNameInput, { target: { value: username } });
+      expect(button).toBeEnabled();
+      fireEvent.click(button);
+      expect(socket.has('joined-room')).toBe(true);
+    }
+  );
 
 });

--- a/client/src/components/__tests__/JoinRoom.test.js
+++ b/client/src/components/__tests__/JoinRoom.test.js
@@ -1,0 +1,135 @@
+// @flow
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import {
+  test,
+  expect,
+  describe,
+  afterEach,
+  beforeEach,
+  jest,
+} from '@jest/globals';
+import { MemoryRouter, Route } from 'react-router-dom';
+import JoinRoom from '../JoinRoom';
+import io, { serverSocket, cleanSocket } from 'utils/__mocks__/MockedSocketIO';
+import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
+import type { UserT, RoomT, JoinRoomRequestT } from 'common/types';
+
+import '@testing-library/jest-dom';
+
+// Join room needs useParams hook, with this personalized router we can have
+// it in test enviroment
+
+type CustomMemoryRouterT = {
+  ui: React$Element<any>,
+  initialEntries: [string],
+  path: string,
+};
+
+function CustomMemoryRouter(props: CustomMemoryRouterT): React$Element<any>{
+  return (
+    <MemoryRouter initialEntries={props.initialEntries}>
+      <Route path={props.path}>
+        {props.ui}
+      </Route>
+    </MemoryRouter>
+  );
+}
+
+describe('JoinRoom component', (): void => {
+
+  const socket = io.connect();
+  let user: ?UserT;
+
+  const setUser: mixed = (user: UserT): void => { user = user; };
+
+  const ui = (
+    <CustomMemoryRouter 
+      ui={<JoinRoom/>}
+      initialEntries={['join']}
+      path={'join'}
+    />
+  );
+
+  const mockedUserState = () => {
+    return { user, setUser }; 
+  };
+
+  beforeEach((): void => {
+    user = undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanSocket();
+  });
+
+  test('JoinRoom renders wihtout crashing', (): void => {
+    render(
+      <ElementWithProviders 
+        ui={ui}
+        mockUserState={mockedUserState()}
+        socket={socket}
+      />
+    );
+    expect(
+      screen.getByRole(
+        'button', 
+        { name: /Join Room/i }
+      )
+    ).toBeInTheDocument();
+  });
+  
+  test('join room button disabled if not username or not roomid', (): void => {
+    render(
+      <ElementWithProviders 
+        ui={ui}
+        mockUserState={mockedUserState()}
+        socket={socket}
+      />
+    );
+    const joinButton = screen.getByRole('button', { name: /Join Room/i });
+    const userNameInput = screen.getByTestId('username');
+    const roomIdInput = screen.getByTestId('roomid');
+    expect(joinButton).toBeDisabled();
+    fireEvent.change(userNameInput, { target: { value: 'username' } });
+    expect(joinButton).toBeDisabled();
+    fireEvent.change(roomIdInput, { target: { value: 'roomid' } });
+    expect(joinButton).toBeEnabled();
+  });
+  
+  test('join room sockets test', (): void => {
+    const username = 'owner';
+    const roomid = 'my-id';
+    let fakeRoom: RoomT = {
+      id: roomid,
+      users: [ ],
+      owner: '',
+      round: 1,
+      time: 30,
+    };
+    socket.on('join-room', (data: JoinRoomRequestT) => {
+      fakeRoom.users.push(data.username);
+      serverSocket.emit('joined-room', fakeRoom);
+    });
+    socket.on('joined-room', (room: RoomT) => {
+      expect(room).toBe(fakeRoom);
+      expect(room.users).toContain(username);
+    });
+    render(
+      <ElementWithProviders 
+        ui={ui}
+        mockUserState={mockedUserState()}
+        socket={socket}
+      />
+    );
+    const joinButton = screen.getByRole('button', { name: /Join Room/i });
+    const userNameInput = screen.getByTestId('username');
+    const roomIdInput = screen.getByTestId('roomid');
+    fireEvent.change(userNameInput, { target: { value: username } });
+    fireEvent.change(roomIdInput, { target: { value: roomid } });
+    expect(joinButton).toBeEnabled();
+    fireEvent.click(joinButton);
+  });
+
+});

--- a/client/src/utils/__mocks__/MockedSocketIO.js
+++ b/client/src/utils/__mocks__/MockedSocketIO.js
@@ -12,7 +12,10 @@ const socket = {
     }
     EVENTS[event] = [func];
   },
-  emit
+  emit,
+  has(event) {
+    return (EVENTS[event]) ? true : false;
+  },
 };
 
 export const io = {


### PR DESCRIPTION
`npm test` #22 
![Screenshot 2021-04-21 13:10:57](https://user-images.githubusercontent.com/40135286/115649470-ffa64380-a2ec-11eb-85d7-7e7ec7c261d7.png)

Basically JoinRoom component should not allow us to make a join-room petition if we do not provide a username and a room id. 
If we provide a valid room id and a valid username we should be able to join the room. 

Error handling testing should be provided when added to the component.