### PR TITLE
Tests for remove user from room

### DIFF
--- a/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
+++ b/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
@@ -35,6 +35,7 @@ describe("removeUserFromRoom", () => {
       removeUserFromRoom(user, rooms);
       expect(rooms[roomId]).toStrictEqual(expectedRoom);
     });
+    // TODO: it removes the user from the user set
   });
   describe("given a user whose room exists and owns it", () => {
     it("does nothing", () => {

--- a/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
+++ b/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
@@ -5,30 +5,77 @@ const { removeUserFromRoom } = require("utils/userUtils");
 import type { RoomT, RoomSetT, UserT, UserSetT, ErrorT } from "common/types";
 
 describe("removeUserFromRoom", () => {
-  it("removes the username from the room user list", () => {
-      const roomId : string = "room-id";
-      const userUsername : string = "user-username";
-      const user : UserT = {
-          id: "user-id",
-          username: userUsername,
-          roomId: roomId,
+  describe("given a user whose room exists and their username appears in the room's list", () => {
+    it("removes the username from the room user list", () => {
+      const roomId: string = "room-id";
+      const user: UserT = {
+        id: "user-id",
+        username: "user-username",
+        roomId: roomId,
       };
-      const ownerId : string = "owner-id";
-      const owner : UserT = {
-          id: ownerId,
-          username: "owner-username",
-          roomId: roomId,
-      }
-      const room : RoomT = {
-          id: roomId,
-          owner: ownerId,
-          round: 1,
-          time: 1,
-          users: [userUsername],
-      }
-      let rooms : RoomSetT = {};
-      rooms[roomId]=room;
-      
-      removeUserFromRoom(user,rooms);
+      const userList: Array<string> = [
+        "username-1",
+        "username-2",
+        "username-3",
+      ];
+      const room: RoomT = {
+        id: roomId,
+        owner: "owner-id",
+        round: 1,
+        time: 1,
+        users: [...userList, user.username],
+      };
+      const expectedRoom: RoomT = {
+        ...room,
+        users: userList,
+      };
+      let rooms: RoomSetT = {};
+      rooms[roomId] = room;
+
+      removeUserFromRoom(user, rooms);
+      expect(rooms[roomId]).toStrictEqual(expectedRoom);
+    });
   });
+  describe("given a user whose room exists and their username doesn't appear in the room's list", () => {
+    it("does nothing", () => {
+      const roomId: string = "room-id";
+      const user: UserT = {
+        id: "user-id",
+        username: "user-username",
+        roomId: roomId,
+      };
+      const userList: Array<string> = [
+        "username-1",
+        "username-2",
+        "username-3",
+      ];
+      const room: RoomT = {
+        id: roomId,
+        owner: "owner-id",
+        round: 1,
+        time: 1,
+        users: userList,
+      };
+      let rooms: RoomSetT = {};
+      rooms[roomId] = room;
+
+      removeUserFromRoom(user, rooms);
+      expect(rooms[roomId]).toStrictEqual(room);
+    });
+  });
+  describe("given a user whose room doesn't exists", () => {
+    it("throws an error", () => {
+      const roomId: string = "room-id";
+      const user: UserT = {
+        id: "user-id",
+        username: "user-username",
+        roomId: roomId,
+      };
+      let rooms: RoomSetT = {};
+      expect(() => {
+        removeUserFromRoom(user, rooms);
+      }).toThrow();
+    });
+  });
+  describe("given an owner", () => {});
 });

--- a/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
+++ b/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
@@ -36,6 +36,28 @@ describe("removeUserFromRoom", () => {
       expect(rooms[roomId]).toStrictEqual(expectedRoom);
     });
   });
+  describe("given a user whose room exists and owns it", () => {
+    it("does nothing", () => {
+      // TODO: removing the owner should change ownership
+      const user: UserT = {
+        id: "user-id",
+        username: "user-username",
+        roomId: "room-id",
+      };
+      const room: RoomT = {
+        id: user.roomId,
+        owner: user.username,
+        round: 1,
+        time: 1,
+        users: ["username-1", "username-2", "username-3"],
+      };
+      const rooms: RoomSetT = {
+        [room.id]: room,
+      };
+      removeUserFromRoom(user, rooms);
+      expect(rooms[room.id]).toStrictEqual(room);
+    });
+  });
   describe("given a user whose room exists and their username doesn't appear in the room's list", () => {
     it("does nothing", () => {
       const roomId: string = "room-id";

--- a/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
+++ b/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
@@ -4,14 +4,13 @@ const { removeUserFromRoom } = require("utils/userUtils");
 
 import type { RoomT, RoomSetT, UserT, UserSetT, ErrorT } from "common/types";
 
-describe("removeUserFromRoom", () => {
-  describe("given a user whose room exists and their username appears in the room's list", () => {
-    it("removes the username from the room user list", () => {
-      const roomId: string = "room-id";
+describe("When removing a user from a room", () => {
+  describe("Given a user whose room exists and their username appears in the room's list", () => {
+    it("Removes the username from the room user list", () => {
       const user: UserT = {
         id: "user-id",
         username: "user-username",
-        roomId: roomId,
+        roomId: "room-id",
       };
       const userList: Array<string> = [
         "username-1",
@@ -19,7 +18,7 @@ describe("removeUserFromRoom", () => {
         "username-3",
       ];
       const room: RoomT = {
-        id: roomId,
+        id: user.roomId,
         owner: "owner-id",
         round: 1,
         time: 1,
@@ -29,16 +28,16 @@ describe("removeUserFromRoom", () => {
         ...room,
         users: userList,
       };
-      let rooms: RoomSetT = {};
-      rooms[roomId] = room;
+      const rooms: RoomSetT = {
+        [room.id]: room
+      };
 
       removeUserFromRoom(user, rooms);
-      expect(rooms[roomId]).toStrictEqual(expectedRoom);
+      expect(rooms[user.roomId]).toStrictEqual(expectedRoom);
     });
-    // TODO: it removes the user from the user set
   });
-  describe("given a user whose room exists and their username is the only one in the room's list", () => {
-    it("keeps the room", () => {
+  describe("Given a user whose room exists and their username is the only one in the room's list", () => {
+    it("Keeps the room", () => {
       // TODO: removing the only user left in the room should delete the room
       const user: UserT = {
         id: "user-id",
@@ -59,8 +58,8 @@ describe("removeUserFromRoom", () => {
       expect(rooms[room.id]).toBeDefined();
     });
   });
-  describe("given a user whose room exists and owns it", () => {
-    it("does nothing", () => {
+  describe("Given a user whose room exists and owns it", () => {
+    it("Does nothing", () => {
       // TODO: removing the owner should change ownership
       const user: UserT = {
         id: "user-id",
@@ -81,13 +80,12 @@ describe("removeUserFromRoom", () => {
       expect(rooms[room.id]).toStrictEqual(room);
     });
   });
-  describe("given a user whose room exists and their username doesn't appear in the room's list", () => {
-    it("does nothing", () => {
-      const roomId: string = "room-id";
+  describe("Given a user whose room exists and their username doesn't appear in the room's list", () => {
+    it("Does nothing", () => {
       const user: UserT = {
         id: "user-id",
         username: "user-username",
-        roomId: roomId,
+        roomId: "room-id",
       };
       const userList: Array<string> = [
         "username-1",
@@ -95,32 +93,31 @@ describe("removeUserFromRoom", () => {
         "username-3",
       ];
       const room: RoomT = {
-        id: roomId,
+        id: user.roomId,
         owner: "owner-id",
         round: 1,
         time: 1,
         users: userList,
       };
-      let rooms: RoomSetT = {};
-      rooms[roomId] = room;
+      const rooms: RoomSetT = {
+        [room.id]: room,
+      };
 
       removeUserFromRoom(user, rooms);
-      expect(rooms[roomId]).toStrictEqual(room);
+      expect(rooms[user.roomId]).toStrictEqual(room);
     });
   });
-  describe("given a user whose room doesn't exists", () => {
-    it("throws an error", () => {
-      const roomId: string = "room-id";
+  describe("Given a user whose room doesn't exists", () => {
+    it("Throws an error", () => {
       const user: UserT = {
         id: "user-id",
         username: "user-username",
-        roomId: roomId,
+        roomId: "room-id",
       };
-      let rooms: RoomSetT = {};
+      const rooms: RoomSetT = {};
       expect(() => {
         removeUserFromRoom(user, rooms);
       }).toThrow();
     });
   });
-  describe("given an owner", () => {});
 });

--- a/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
+++ b/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
@@ -1,0 +1,34 @@
+// @flow
+const { describe, it, expect, beforeEach } = require("@jest/globals");
+const { removeUserFromRoom } = require("utils/userUtils");
+
+import type { RoomT, RoomSetT, UserT, UserSetT, ErrorT } from "common/types";
+
+describe("removeUserFromRoom", () => {
+  it("removes the username from the room user list", () => {
+      const roomId : string = "room-id";
+      const userUsername : string = "user-username";
+      const user : UserT = {
+          id: "user-id",
+          username: userUsername,
+          roomId: roomId,
+      };
+      const ownerId : string = "owner-id";
+      const owner : UserT = {
+          id: ownerId,
+          username: "owner-username",
+          roomId: roomId,
+      }
+      const room : RoomT = {
+          id: roomId,
+          owner: ownerId,
+          round: 1,
+          time: 1,
+          users: [userUsername],
+      }
+      let rooms : RoomSetT = {};
+      rooms[roomId]=room;
+      
+      removeUserFromRoom(user,rooms);
+  });
+});

--- a/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
+++ b/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
@@ -37,6 +37,28 @@ describe("removeUserFromRoom", () => {
     });
     // TODO: it removes the user from the user set
   });
+  describe("given a user whose room exists and their username is the only one in the room's list", () => {
+    it("keeps the room", () => {
+      // TODO: removing the only user left in the room should delete the room
+      const user: UserT = {
+        id: "user-id",
+        username: "user-username",
+        roomId: "room-id",
+      };
+      const room: RoomT = {
+        id: user.roomId,
+        owner: "owner-id",
+        round: 1,
+        time: 1,
+        users: [user.username],
+      };
+      const rooms: RoomSetT = {
+        [room.id]: room,
+      };
+      removeUserFromRoom(user, rooms);
+      expect(rooms[room.id]).toBeDefined();
+    });
+  });
   describe("given a user whose room exists and owns it", () => {
     it("does nothing", () => {
       // TODO: removing the owner should change ownership


### PR DESCRIPTION
Solves #31 

***Requirements***

When we call the function to remove a user from a room:
- Given a user whose room exists and their username appears in the room's list:
  - Then remove the username from the list
- Given a user whose room exists and their username doesn't appear in the room's list
  - Then do nothing
- Given a user whose room doesn't exist
  - Then throw an error

***Further questions***

- What should the code do if you want to remove the owner?
- Shouldn't we change the user's room id too?
- Shouldn't we delete the room if it becomes empty?
- What happens if the username is duplicated? Shouldn't we be checking for id instead?

![image](https://user-images.githubusercontent.com/17532768/115668381-aa7a2a00-a30c-11eb-8a57-97d0c4417994.png)
