### PR TITLE
fixed multiple socket on event calls

### DIFF
--- a/client/src/components/CreateRoom.js
+++ b/client/src/components/CreateRoom.js
@@ -18,11 +18,15 @@ function CreateRoom(): React$Element<any> {
     socket.emit('create-room', data, errorCallBack);
   }
 
-  useEffect((): void => {
+  useEffect((): any => {
     socket.on('joined-room', (room: RoomT): void => {
       setUser({ username, roomId: room.id});
       history.push(`/room/${room.id}`);
     });
+
+    return function cleanup() {
+      socket.off('joined-room');
+    };
   }, [socket, history]);
 
   return (

--- a/client/src/components/JoinRoom.js
+++ b/client/src/components/JoinRoom.js
@@ -24,11 +24,15 @@ function JoinRoom(): React$Element<any> {
     if(id) setRoomId(id);
   }, [id]);
 
-  useEffect((): void => {
+  useEffect((): any => {
     socket.on('joined-room', (room: RoomT): void => {
       setUser({ username, roomId: room });
       history.push(`/room/${room.id}`);
     });
+
+    return function cleanup() {
+      socket.off('joined-room');
+    };
   }, [socket, history]);
 
   return (

--- a/client/src/utils/__mocks__/MockedSocketIO.js
+++ b/client/src/utils/__mocks__/MockedSocketIO.js
@@ -6,16 +6,21 @@ function emit(event: string, ...args: any) {
 }
 
 const socket = {
-  on(event, func) {
+  on(event: string, func) {
     if (EVENTS[event]) {
       return EVENTS[event].push(func);
     }
     EVENTS[event] = [func];
   },
   emit,
-  has(event) {
+  has(event: string) {
     return (EVENTS[event]) ? true : false;
   },
+  off(event: string) {
+    // with tests we need to check if the event was called, so we do not 
+    // remove the event with this mock of socketio
+    return;
+  } 
 };
 
 export const io = {


### PR DESCRIPTION
closes #43 
We needed to cleanup the useEffect calls. 
- Before: 
  - First call:
![ss1](https://user-images.githubusercontent.com/40135286/115904269-359d1200-a42a-11eb-9eae-649462dd9f89.png)
  - Second call (we received +1 object that needed) :
![ss2](https://user-images.githubusercontent.com/40135286/115904347-4a79a580-a42a-11eb-9bc4-deaff1e34f7c.png)

- After:
  - First call:
![ss3](https://user-images.githubusercontent.com/40135286/115904470-6d0bbe80-a42a-11eb-8b2c-451f6a81fe25.png)
  - Second call:
![ss4](https://user-images.githubusercontent.com/40135286/115904474-6e3ceb80-a42a-11eb-9aa3-694b825aba69.png)
 

