### PR TITLE
Remove user method

### DIFF
--- a/server/src/sockets/handlers/roomHandler.js
+++ b/server/src/sockets/handlers/roomHandler.js
@@ -2,7 +2,6 @@
 const {
   createRoom,
   removeRoom,
-  emitRoomUpdate,
   joinUserToRoomById,
 } = require('utils/roomUtils');
 

--- a/server/src/sockets/handlers/userHandler.js
+++ b/server/src/sockets/handlers/userHandler.js
@@ -1,6 +1,6 @@
 // @flow
-const { removeRoom, emitRoomUpdate } = require('utils/roomUtils');
-const { removeUserFromRoom, removeUser } = require('utils/userUtils');
+const { emitRoomUpdate } = require('utils/roomUtils');
+const { removeUserById } = require('utils/userUtils');
 
 import type { RoomSetT, UserSetT } from 'common/types';
 
@@ -12,25 +12,7 @@ module.exports = (
 ) => {
   const disconnect = (): void => {
     console.log(`Client ${socket.id} disconnected`);
-    if(!users[socket.id]) return;
-    try {
-      const user = users[socket.id];
-      removeUser(user, users);
-      if(!rooms[user.roomId]) return;
-      removeUserFromRoom(user, rooms);
-      if (!rooms[user.roomId].users.length) {
-        console.log(`removing empty room ${user.roomId}`);
-        removeRoom(rooms[user.roomId], rooms);
-      }
-      else emitRoomUpdate(rooms[user.roomId], io);
-      /* 
-      TODO
-      Check if the user that left was the owner, if true we need to change the
-      current owner. Implement this when we can test if it works. 
-      */
-    } catch (error) {
-      console.log(error);
-    }
+    removeUserById(socket.id, users, rooms);
   }
   
   socket.on('disconnect', disconnect);

--- a/server/src/sockets/handlers/userHandler.js
+++ b/server/src/sockets/handlers/userHandler.js
@@ -1,5 +1,4 @@
 // @flow
-const { emitRoomUpdate } = require('utils/roomUtils');
 const { removeUserById } = require('utils/userUtils');
 
 import type { RoomSetT, UserSetT } from 'common/types';
@@ -12,7 +11,7 @@ module.exports = (
 ) => {
   const disconnect = (): void => {
     console.log(`Client ${socket.id} disconnected`);
-    removeUserById(socket.id, users, rooms);
+    removeUserById(socket.id, users, rooms, io);
   }
   
   socket.on('disconnect', disconnect);

--- a/server/src/utils/__tests__/userUtils/removeUserById.test.js
+++ b/server/src/utils/__tests__/userUtils/removeUserById.test.js
@@ -1,0 +1,65 @@
+// @flow
+const { describe, it, expect, beforeEach } = require("@jest/globals");
+const { createUser, removeUserById } = require("utils/userUtils");
+
+import type { RoomT, RoomSetT, UserT, UserSetT } from "common/types";
+
+let user: UserT; 
+
+const roomId: string = "room-id";
+const userId: string = "user-id";
+
+const roomTemplate: RoomT = {
+  id: "template-id",
+  owner: "owner-username",
+  round: 1,
+  time: 1,
+  users: ["username-1", "username-2", "username-3"],
+};
+
+const users: UserSetT = {};
+const rooms: RoomSetT = {};
+
+describe("When removing a user by id", () => {
+  beforeEach(() => {
+    user = createUser(
+      userId,
+      "user-username",
+      roomId,
+      users,
+    );
+  });
+  it("Should not be in the userSet anymore", () => {
+    removeUserById(userId, users, rooms);
+    expect(users[userId]).toBeUndefined();
+  });
+  describe("When is the owner of the room", () => {
+    beforeEach(() => {
+      rooms[roomId] = {
+        ...roomTemplate,
+        id: roomId,
+        owner: user.username,
+        users: [user.username],
+      }
+    });
+    describe("When it's alone in the room", () => {
+      it("The room should be removed", () => {
+        removeUserById(userId, users, rooms);
+        expect(rooms[roomId]).toBeUndefined();
+      });
+    });
+    describe("When the room contains more users", () => {
+      beforeEach(() => {
+        rooms[roomId].users = [...roomTemplate.users, user.username];
+      });
+      it("Should be removed from the room", () => {
+        removeUserById(userId, users, rooms);
+        expect(rooms[roomId].users).not.toContain(user.username);
+      });
+      it("Should not be the owner of the room anymore", () => {
+        removeUserById(userId, users, rooms);
+        expect(rooms[roomId].owner).not.toBe(user.username);
+      });
+    });
+  });
+});

--- a/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
+++ b/server/src/utils/__tests__/userUtils/removeUserFromRoom.test.js
@@ -34,8 +34,7 @@ describe("When removing a user from a room", () => {
     });
   });
   describe("Given a user whose room exists and their username is the only one in the room's list", () => {
-    it("Keeps the room", () => {
-      // TODO: removing the only user left in the room should delete the room
+    it("Deletes the room", () => {
       const room: RoomT = {
         ...roomTemplate,
         users: [user.username],
@@ -44,13 +43,14 @@ describe("When removing a user from a room", () => {
         [room.id]: room,
       };
       removeUserFromRoom(user, rooms);
-      expect(rooms[room.id]).toBeDefined();
+      expect(rooms[room.id]).toBeUndefined();
     });
   });
   describe("Given a user whose room exists and owns it", () => {
     const room: RoomT = {
       ...roomTemplate,
       owner: user.username,
+      users: [...roomTemplate.users, user.username],
     };
     const rooms: RoomSetT = {
       [room.id]: room,
@@ -64,6 +64,14 @@ describe("When removing a user from a room", () => {
     });
     it("Removes the new owner from the list", () => {
       removeUserFromRoom(user, rooms);
+      expect(rooms[room.id].owner).toStrictEqual("username-1");
+      expect(rooms[room.id].users).toStrictEqual(roomTemplate.users);
+      const newOwner: UserT = {
+        id: "new-owner-id",
+        roomId: room.id,
+        username: rooms[room.id].owner,
+      };
+      removeUserFromRoom(newOwner, rooms);
       expect(rooms[room.id].users).toStrictEqual(["username-2", "username-3"]);
     });
   });

--- a/server/src/utils/roomUtils.js
+++ b/server/src/utils/roomUtils.js
@@ -65,13 +65,13 @@ const transferOwnership = (
   };
 };
 
-const emitRoomUpdate = (room: RoomT, io: any) => {
-  io.in(room.id).emit('room-update', room);
+const emitToRoom = (roomId: string, petition: string, data: any, io: any) => {
+  io.in(roomId).emit(petition, data);
 }
 
 module.exports = {
   createRoom,
-  emitRoomUpdate,
+  emitToRoom,
   joinUserToRoomById,
   removeRoom,
   transferOwnership,

--- a/server/src/utils/roomUtils.js
+++ b/server/src/utils/roomUtils.js
@@ -59,13 +59,9 @@ const transferOwnership = (
   room: RoomT,
   newOwnerUsername: string,
 ): RoomT => {
-  const remainingUsers = room.users.filter(
-    (username) => username != newOwnerUsername
-  );
   return {
     ...room,
     owner: newOwnerUsername,
-    users: [...remainingUsers, room.owner],
   };
 };
 

--- a/server/src/utils/userUtils.js
+++ b/server/src/utils/userUtils.js
@@ -3,7 +3,7 @@ import type { RoomT, RoomSetT, UserT, UserSetT } from 'common/types';
 const { 
   transferOwnership, 
   removeRoom, 
-  emitRoomUpdate,
+  emitToRoom,
 } = require("utils/roomUtils");
 
 const createUser = (
@@ -15,7 +15,7 @@ const createUser = (
   return users[id] = { id, username, roomId };
 }
 
-const removeUserFromRoom = (user: UserT, rooms: RoomSetT): void => {
+const removeUserFromRoom = (user: UserT, rooms: RoomSetT, io: any): void => {
   const room = getUserRoom(user, rooms);
   room.users = room.users.filter(name => name != user.username);
   if(!room.users.length) {
@@ -26,6 +26,7 @@ const removeUserFromRoom = (user: UserT, rooms: RoomSetT): void => {
     room.owner == user.username
     ? transferOwnership(room, room.users[0])
     : room;
+  if(io) emitToRoom(room.id, 'room-update', rooms[room.id], io);
 }
 
 const getUserRoom = (user: UserT, rooms: RoomSetT): RoomT => {
@@ -40,12 +41,13 @@ const removeUserById = (
   userId: string,
   users: UserSetT,
   rooms: RoomSetT,
+  io: any,
 ): void => {
   if(!users[userId]) return;
   const user = users[userId];
   removeUser(user, users);
   if(!rooms[user.roomId]) return;
-  removeUserFromRoom(user, rooms); // handles transfer owner
+  removeUserFromRoom(user, rooms, io); // handles transfer owner
 }
 
 module.exports = {


### PR DESCRIPTION
Closes #55 
Generic remove user method. This removes the user from the userSet, the room, transfers the ownership if needed, and erases the room if it's empty. Besides, it emits the room update through `emitToRoom`. The method is tested later in the stack. 

Modify `removeUserFromRoom.test` to handle the new implementation. 

`npm test`
![byidtestpre](https://user-images.githubusercontent.com/40135286/115971700-8a668880-a50f-11eb-9e45-cb3500b3e908.png)

