### PR TITLE
Update ui when user join event is fired

### DIFF
--- a/client/src/components/__tests__/CreateRoom.test.js
+++ b/client/src/components/__tests__/CreateRoom.test.js
@@ -88,7 +88,7 @@ describe('CreateRoom component', (): void => {
         time: 30,
       };
       // mock of what the server should do. 
-      socket.on('create-room', (data: CreateRoomRequestT) => {
+      serverSocket.on('create-room', (data: CreateRoomRequestT) => {
         fakeRoom.users = [data.username];
         fakeRoom.owner = data.username;
         serverSocket.emit('joined-room', fakeRoom);

--- a/client/src/components/__tests__/JoinRoom.test.js
+++ b/client/src/components/__tests__/JoinRoom.test.js
@@ -87,7 +87,7 @@ describe('JoinRoom component', (): void => {
         round: 1,
         time: 30,
       };
-      socket.on('join-room', (data: JoinRoomRequestT) => {
+      serverSocket.on('join-room', (data: JoinRoomRequestT) => {
         fakeRoom.users.push(data.username);
         serverSocket.emit('joined-room', fakeRoom);
       });

--- a/client/src/components/__tests__/lobby/GetUserInLobby.test.js
+++ b/client/src/components/__tests__/lobby/GetUserInLobby.test.js
@@ -1,0 +1,57 @@
+//@flow
+
+import React from "react";
+import "@testing-library/jest-dom";
+import {
+  render,
+  screen,
+  cleanup,
+  queryByText,
+  act,
+} from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import io, { cleanSocket, serverSocket } from "utils/__mocks__/MockedSocketIO";
+import Lobby from "components/lobby/Lobby";
+import SocketContext from "contexts/SocketContext";
+import type {
+  UserInLobbyT,
+  ErrorCallBackT,
+  UsersInLobbyCallbackT,
+} from "common/types";
+
+describe("When receive get-users-in-lobby request", () => {
+  const mockUsers: Array<UserInLobbyT> = [
+    { username: "test-user-1", state: "Ready" },
+    { username: "test-user-2", state: "Waiting" },
+  ];
+  const socket = io.connect();
+  let receivedUsers: ?Array<UserInLobbyT> = null;
+  beforeEach(() => {
+    serverSocket.on(
+      "get-users-in-lobby",
+      (
+        errorCallBack: ErrorCallBackT,
+        succesCallback: UsersInLobbyCallbackT
+      ) => {
+        succesCallback(mockUsers);
+      }
+    );
+    render(
+      <SocketContext.Provider value={socket}>
+        <Lobby />
+      </SocketContext.Provider>
+    );
+    serverSocket.emit("get-users-in-lobby", (answer: Array<UserInLobbyT>) => {
+      receivedUsers = answer;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanSocket();
+  });
+
+  it("Returns the current list of users in lobby", () => {
+    expect(receivedUsers).toStrictEqual(mockUsers);
+  });
+});

--- a/client/src/components/__tests__/lobby/JoinLobby.test.js
+++ b/client/src/components/__tests__/lobby/JoinLobby.test.js
@@ -1,0 +1,51 @@
+//@flow
+
+import React from "react";
+import "@testing-library/jest-dom";
+import {
+  render,
+  screen,
+  cleanup,
+  queryByText,
+  act,
+} from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import io, { cleanSocket, serverSocket } from "utils/__mocks__/MockedSocketIO";
+import Lobby from "components/lobby/Lobby";
+import SocketContext from "contexts/SocketContext";
+
+describe("When user joins lobby", () => {
+  const socket = io.connect();
+  const eventsEmitted: Array<string> = [];
+  beforeEach(() => {
+    serverSocket.on("get-users-in-lobby", () => {
+      eventsEmitted.push("get-users-in-loby");
+    });
+    serverSocket.on("user-joined", () => {
+      eventsEmitted.push("user-joined");
+    });
+    
+    render(
+      <SocketContext.Provider value={socket}>
+        <Lobby />
+      </SocketContext.Provider>
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanSocket();
+    eventsEmitted.length = 0;
+  });
+
+  it("Emits an event to get the users in lobby", () => {
+    expect(eventsEmitted.includes("get-users-in-loby")).toBe(true);
+  });
+  it("Sets the user list as empty", ()=>{
+    const users = screen.queryAllByRole("listitem");
+    expect(users.length).toBe(0);
+  })
+  it("Doesn't emit an event to notify join", () => {
+    expect(eventsEmitted.includes("user-joined")).toBe(false);
+  });
+});

--- a/client/src/components/__tests__/lobby/UserJoins.test.js
+++ b/client/src/components/__tests__/lobby/UserJoins.test.js
@@ -1,0 +1,56 @@
+//@flow
+
+import React from "react";
+import "@testing-library/jest-dom";
+import {
+  render,
+  screen,
+  cleanup,
+  queryByText,
+  act,
+} from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import io, { cleanSocket, serverSocket } from "utils/__mocks__/MockedSocketIO";
+import type { UserT } from "common/types";
+import Lobby from "components/lobby/Lobby";
+import SocketContext from "contexts/SocketContext";
+
+describe("When user joins lobby", () => {
+  const socket = io.connect();
+  describe("Given a user that wasn't already in the lobby", () => {
+    beforeEach(() => {
+      render(
+        <SocketContext.Provider value={socket}>
+          <Lobby />
+        </SocketContext.Provider>
+      );
+      const user: UserT = {
+        id: "test-user-id",
+        roomId: "test-room-id",
+        username: "test-username",
+      };
+      act(() => {
+        serverSocket.emit("user-joined", user);
+      });
+    });
+
+    afterEach(() => {
+      cleanup();
+      cleanSocket();
+    });
+
+    it("Adds one item to the user list", () => {
+      const users = screen.getAllByRole("listitem");
+      expect(users.length).toBe(5);
+    });
+    it("Includes the username", () => {
+      const userDiv = screen.queryByText(/test-username/);
+      expect(userDiv).not.toBeNull();
+    });
+    it("Sets the new user as Waiting", () => {
+      const userDiv = screen.getByText(/test-username/);
+      const waitingDiv = queryByText(userDiv, /Waiting/);
+      expect(waitingDiv).not.toBeNull();
+    });
+  });
+});

--- a/client/src/components/lobby/Lobby.js
+++ b/client/src/components/lobby/Lobby.js
@@ -1,23 +1,39 @@
 //@flow
 
-import React from "react";
-import type { UserInLobbyT } from "common/types";
+import React, { useEffect, useContext, useState } from "react";
+import type { UserInLobbyT, UserT } from "common/types";
 import UserList from "./UserList";
 import ReadyButton from "./ReadyButton";
 import PlayButton from "./PlayButton";
+import SocketContext from "contexts/SocketContext";
 
-const users: Array<UserInLobbyT> = [
-  { id: "id1", username: "username1", roomId: "room", state: "Ready"},
+const mockUsers: Array<UserInLobbyT> = [
+  { id: "id1", username: "username1", roomId: "room", state: "Ready" },
   { id: "id2", username: "username2", roomId: "room", state: "Waiting" },
   { id: "id3", username: "username3", roomId: "room", state: "Waiting" },
   { id: "id4", username: "username4", roomId: "room", state: "Ready" },
 ];
 
 const Lobby = (): React$Element<any> => {
+  const socket = useContext(SocketContext);
+  const [userList: Array<UserInLobbyT>, setUserList] = useState(mockUsers);
+  const addUserToList = (user: UserT) => {
+    const userInLobby: UserInLobbyT = {
+      ...user,
+      state: "Waiting",
+    };
+    const updatedUserList: Array<UserInLobbyT> = [...userList, userInLobby];
+    setUserList(updatedUserList);
+  };
+  useEffect(() => {
+    socket.on("user-joined", (user: UserT) => {
+      addUserToList(user);
+    });
+  });
   return (
     <div>
       <ReadyButton />
-      <UserList users={users} />
+      <UserList users={userList} />
       <PlayButton />
     </div>
   );

--- a/client/src/components/lobby/Lobby.js
+++ b/client/src/components/lobby/Lobby.js
@@ -1,34 +1,49 @@
 //@flow
 
-import React, { useEffect, useContext, useState } from "react";
-import type { UserInLobbyT, UserT } from "common/types";
+import React, { useEffect, useContext, useState, useRef } from "react";
+import type { UserInLobbyT, UsersInLobbyCallbackT } from "common/types";
 import UserList from "./UserList";
 import ReadyButton from "./ReadyButton";
 import PlayButton from "./PlayButton";
 import SocketContext from "contexts/SocketContext";
-
-const mockUsers: Array<UserInLobbyT> = [
-  { id: "id1", username: "username1", roomId: "room", state: "Ready" },
-  { id: "id2", username: "username2", roomId: "room", state: "Waiting" },
-  { id: "id3", username: "username3", roomId: "room", state: "Waiting" },
-  { id: "id4", username: "username4", roomId: "room", state: "Ready" },
-];
+import errorCallBack from "utils/errorCallBack";
 
 const Lobby = (): React$Element<any> => {
   const socket = useContext(SocketContext);
-  const [userList: Array<UserInLobbyT>, setUserList] = useState(mockUsers);
-  const addUserToList = (user: UserT) => {
-    const userInLobby: UserInLobbyT = {
-      ...user,
-      state: "Waiting",
-    };
-    const updatedUserList: Array<UserInLobbyT> = [...userList, userInLobby];
-    setUserList(updatedUserList);
-  };
+  const [userList: Array<UserInLobbyT>, setUserList] = useState([]);
+
   useEffect(() => {
-    socket.on("user-joined", (user: UserT) => {
-      addUserToList(user);
+    socket.on("get-users-in-lobby", (callback: UsersInLobbyCallbackT) => {
+      callback(userList);
     });
+    return () => {
+      socket.off("get-users-in-lobby");
+    };
+  });
+
+  useEffect(() => {
+    socket.emit("get-users-in-lobby", errorCallBack, (users) => {
+      setUserList(users);
+      socket.emit("user-joined");
+    });
+  }, [socket]);
+
+  const firstUpdate = useRef(true);
+  useEffect(() => {
+    if (!firstUpdate.current) {
+      socket.on("user-joined", (username: string) => {
+        const userInLobby: UserInLobbyT = {
+          username: username,
+          state: "Waiting",
+        };
+        const updatedUserList: Array<UserInLobbyT> = [...userList, userInLobby];
+        setUserList(updatedUserList);
+      });
+      return () => {
+        socket.off("user-joined");
+      };
+    }
+    firstUpdate.current = false;
   });
   return (
     <div>

--- a/client/src/components/lobby/UserList.js
+++ b/client/src/components/lobby/UserList.js
@@ -2,7 +2,6 @@
 
 import React from "react";
 import type { UserInLobbyT } from "common/types";
-import type { UserPropsT } from "./User";
 import User from "./User";
 
 export type UserListPropsT = {|

--- a/client/src/components/lobby/UserList.js
+++ b/client/src/components/lobby/UserList.js
@@ -13,7 +13,7 @@ const UserList = (props: UserListPropsT): React$Element<any> => {
   return (
     <ul>
       {props.users.map((user) => (
-        <User user={user} />
+        <li key={user.username}><User user={user} /></li>
       ))}
     </ul>
   );

--- a/common/types.js
+++ b/common/types.js
@@ -12,3 +12,4 @@ export type { LeaveRoomRequestT } from 'types/leaveRoomRequestType';
 export type { MessageT } from 'types/messageType';
 export type { MessageListT } from 'types/messageListType';
 export type { UserInLobbyT } from 'types/userInLobbyType';
+export type { UsersInLobbyCallbackT } from 'types/usersInLobbyCallbackType';

--- a/common/types/userInLobbyType.js
+++ b/common/types/userInLobbyType.js
@@ -1,8 +1,7 @@
 // @flow
 import type { UserReadyStateT } from "./userReadyStateType";
-import type { UserT } from "./userType";
 
 export type UserInLobbyT = {|
-  ...UserT,
+  username: string,
   state: UserReadyStateT,
 |};

--- a/common/types/usersInLobbyCallbackType.js
+++ b/common/types/usersInLobbyCallbackType.js
@@ -1,0 +1,5 @@
+// @flow
+
+import type { UserInLobbyT } from './userInLobbyType';
+
+export type UsersInLobbyCallbackT = (users: Array<UserInLobbyT>) => void;

--- a/server/src/sockets/handlers/roomHandler.js
+++ b/server/src/sockets/handlers/roomHandler.js
@@ -4,6 +4,7 @@ const {
   removeRoom,
   emitRoomMessage,
   joinUserToRoomById,
+  emitToRoom,
 } = require('utils/roomUtils');
 
 const {
@@ -12,6 +13,8 @@ const {
   removeUser,
   getUserRoom,
   removeUserById,
+  getOwner,
+  getUser,
 } = require('utils/userUtils');
 
 import type {
@@ -23,6 +26,8 @@ import type {
   CreateRoomRequestT,
   LeaveRoomRequestT,
   MessageT, 
+  UserInLobbyT,
+  UsersInLobbyCallbackT,
 } from 'common/types';
 
 module.exports = (
@@ -82,8 +87,37 @@ module.exports = (
     emitRoomMessage(room, data, socket);
   }
 
+  const getOwnerSocket = (roomId: string): ?any => {
+    const owner = getOwner(roomId, users, rooms);
+    if (!owner) return null;
+    return io.sockets.sockets.get(owner.id);
+  };
+
+  const getUsersInLobbyHandler = (
+    errorCallback: ErrorCallBackT,
+    successCallback: UsersInLobbyCallbackT
+  ): void => {
+    const user = getUser(socket.id, users);
+    if (!user) return console.error({ error: "couldn't find user" });
+    const ownerSocket = getOwnerSocket(user.roomId);
+    if (!ownerSocket)
+      return errorCallback({ error: "couldn't get owner socket" });
+    ownerSocket.emit("get-users-in-lobby", (response: Array<UserInLobbyT>) => {
+      successCallback(response);
+    });
+  };
+
+  const userJoinedLobbyHandler = (
+  ): void => {
+    const user = getUser(socket.id, users);
+    if (!user) return console.error({ error: "couldn't find user" });
+    emitToRoom(user.roomId, "user-joined", user.username, io);
+  }
+
   socket.on('create-room', createRoomHandler);
   socket.on('join-room', joinRoomHandler);
   socket.on('leave-room', leaveRoomHandler);
   socket.on('send-message', sendMessageHandler);
+  socket.on('get-users-in-lobby', getUsersInLobbyHandler);
+  socket.on('user-joined', userJoinedLobbyHandler);
 }

--- a/server/src/utils/userUtils.js
+++ b/server/src/utils/userUtils.js
@@ -1,5 +1,5 @@
 // @flow
-import type { RoomT, RoomSetT, UserT, UserSetT } from 'common/types';
+import type { RoomT, RoomSetT, UserT, UserSetT, ErrorT } from 'common/types';
 const { 
   transferOwnership, 
   removeRoom, 
@@ -50,10 +50,41 @@ const removeUserById = (
   removeUserFromRoom(user, rooms, io); // handles transfer owner
 }
 
+const getUserId = (
+  username: string,
+  roomId: string,
+  users: UserSetT
+): ?string => {
+  const userId = Object.keys(users).find(
+    (userId) =>
+      users[userId].username == username && users[userId].roomId == roomId
+  );
+  return userId;
+};
+
+const getUser = (id: string, users: UserSetT): ?UserT => {
+  return users[id];
+}
+
+const getOwner = (
+  roomId: string,
+  users: UserSetT,
+  rooms: RoomSetT,
+): ?UserT => {
+  const room = rooms[roomId];
+  if (!room) return null;
+  const owner = room.owner;
+  const ownerId = getUserId(owner, roomId, users);
+  if (!ownerId) return null;
+  return getUser(ownerId, users);
+};
+
 module.exports = {
   createUser,
   removeUser,
   removeUserById,
   removeUserFromRoom,
   getUserRoom,
+  getOwner,
+  getUser,
 };


### PR DESCRIPTION
Closes #60 

Given a user that isn't already in the lobby
When a *user-joined* event is received with that user
The lobby should refresh the ui to include the new user.

We specifically guarantee that:
- A new item is added to the user list
- The username of the new user is included 
- The new user is shown as *Waiting*

![image](https://user-images.githubusercontent.com/17532768/115981610-97f53000-a55a-11eb-9e3c-99916789cc2b.png)
