### PR TITLE
call removeUserById when a users requests to leave the room

### DIFF
--- a/server/src/sockets/handlers/roomHandler.js
+++ b/server/src/sockets/handlers/roomHandler.js
@@ -11,6 +11,7 @@ const {
   removeUserFromRoom,
   removeUser,
   getUserRoom,
+  removeUserById,
 } = require('utils/userUtils');
 
 import type {
@@ -67,7 +68,7 @@ module.exports = (
     data: LeaveRoomRequestT,
     callback: ErrorCallBackT,
   ): void => {
-    removeUserFromRoom(data.user, rooms);
+    removeUserById(data.user.id, users, rooms, io);
     socket.emit('left-room');
   }
 


### PR DESCRIPTION
This handles the room ownership transfer and deletes the user from the set (is no needed anymore). Also, notify the rest of the room with `room-update`. Maybe we should change this for `user-left`?. 