### PR TITLE
npm run dev run tests only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "server": "npm start --prefix ./server",
     "client": "npm start --prefix ./client",
     "test": "npm run test --prefix ./server && npm run test --prefix ./client -- --watchAll=false",
-    "predev": "npm test",
     "dev": "concurrently --kill-others \"npm run server\" \"npm run client\"",
     "flow": "flow",
     "init-server": "npm i --prefix ./server",


### PR DESCRIPTION
closes #76 
We are already running `npm test` inside server and client with prestart, so predev is not needed. 
`npm run dev`
![1](https://user-images.githubusercontent.com/40135286/116436951-876edf00-a812-11eb-87eb-ef4aa98fd19b.png)
