### PR TITLE
Server forwards user-joined event to everyone in the room

### DIFF
--- a/server/src/sockets/handlers/roomHandler.js
+++ b/server/src/sockets/handlers/roomHandler.js
@@ -4,6 +4,7 @@ const {
   removeRoom,
   emitRoomMessage,
   joinUserToRoomById,
+  emitToRoom,
 } = require('utils/roomUtils');
 
 const {
@@ -106,9 +107,17 @@ module.exports = (
     });
   };
 
+  const userJoinedLobbyHandler = (
+  ): void => {
+    const user = getUser(socket.id, users);
+    if (!user) return console.error({ error: "couldn't find user" });
+    emitToRoom(user.roomId, "user-joined", user.username, io);
+  }
+
   socket.on('create-room', createRoomHandler);
   socket.on('join-room', joinRoomHandler);
   socket.on('leave-room', leaveRoomHandler);
   socket.on('send-message', sendMessageHandler);
   socket.on('get-users-in-lobby', getUsersInLobbyHandler);
+  socket.on('user-joined', userJoinedLobbyHandler);
 }


### PR DESCRIPTION
closes #82 

When a user is ready to become visible to everyone else, they emit an event.
In this pull request the server forwards that event to everyone in the room.

This is the last pull request in the stack.

This is how everything together looks:

![antes](https://user-images.githubusercontent.com/17532768/116620101-fc234580-a906-11eb-9538-c4eece576145.png)

![despues](https://user-images.githubusercontent.com/17532768/116620144-0d6c5200-a907-11eb-9f2d-7f18dd603b4c.png)

