### PR TITLE
enforce using element with providers for future tests

### DIFF
--- a/client/src/__tests__/App.test.js
+++ b/client/src/__tests__/App.test.js
@@ -10,11 +10,11 @@ import {
   jest,
 } from '@jest/globals';
 import { MemoryRouter } from 'react-router-dom';
-import MockedProvider from 'providers/__mocks__/MockedProvider';
-import SocketContext from 'contexts/SocketContext';
-import UserContext from 'contexts/UserContext';
 import io from 'utils/__mocks__/MockedSocketIO';
 import App from '../App';
+import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
+import mockedRoomState from 'utils/__mocks__/mockedRoomState';
+import mockedUserState from 'utils/__mocks__/mockedUserState';
 
 import '@testing-library/jest-dom';
 
@@ -36,13 +36,15 @@ describe('App component', () => {
   test('App routing test', () => {
     const mockUserState = {user: undefined, setUser: () => {}};
     render(
-      <MockedProvider value={mockUserState} context={UserContext}>
-        <MockedProvider value={socket} context={SocketContext}>
-          <MemoryRouter initialEntries={['/create']}>
-            <App />
-          </MemoryRouter>
-        </MockedProvider>
-      </MockedProvider>
+      <MemoryRouter initialEntries={['/create']}>
+        <ElementWithProviders 
+          mockedRoomState={mockedRoomState}
+          mockedUserState={mockUserState}
+          socket={socket}
+        >
+          <App/>
+        </ElementWithProviders>
+      </MemoryRouter>
     );
     expect(
       screen.getByRole(

--- a/client/src/components/Chat/Chat.js
+++ b/client/src/components/Chat/Chat.js
@@ -15,10 +15,12 @@ function Chat(): React$Element<any> {
   const [messages: MessageT, setMessages] = useState([]);
 
   const handleSendMessage = (): void => {
-		const newMessage: MessageT = { message: textMessage, sender: user };
-		socket.emit('send-message', newMessage, errorCallBack);
-		setTextMessage('');
-    setMessages([...messages, newMessage]);
+		if(user) {
+			const newMessage: MessageT = { message: textMessage, sender: user };
+			socket.emit('send-message', newMessage, errorCallBack);
+			setTextMessage('');
+			setMessages([...messages, newMessage]);
+		}
 	}
 
   useEffect((): any => {

--- a/client/src/components/CreateRoom.js
+++ b/client/src/components/CreateRoom.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import RoomContext from 'contexts/RoomContext';
 import SocketContext from 'contexts/SocketContext';
 import UserContext from 'contexts/UserContext';
 import errorCallBack from 'utils/errorCallBack';
@@ -12,6 +13,7 @@ import type { CreateRoomRequestT, RoomT } from 'common/types';
 function CreateRoom(): React$Element<any> {
   const history: any = useHistory();
   const socket: any = useContext(SocketContext);
+  const { setRoom } = useContext(RoomContext);
   const { setUser } = useContext(UserContext);
   const [username: string, setUsername: mixed] = useState('');
 
@@ -23,6 +25,7 @@ function CreateRoom(): React$Element<any> {
   useEffect((): any => {
     socket.on('joined-room', (room: RoomT): void => {
       toast.success('Room created!');
+      setRoom(room);
       setUser({ username, roomId: room.id, id: socket.id });
       history.push(`/room/${room.id}`);
     });

--- a/client/src/components/JoinRoom.js
+++ b/client/src/components/JoinRoom.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { useContext, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import RoomContext from 'contexts/RoomContext';
 import SocketContext from 'contexts/SocketContext';
 import UserContext from 'contexts/UserContext';
 import errorCallBack from 'utils/errorCallBack';
@@ -13,6 +14,7 @@ function JoinRoom(): React$Element<any> {
   const { id } = useParams();
   const history = useHistory();
   const socket = useContext(SocketContext);
+  const { setRoom } = useContext(RoomContext);
   const { setUser } = useContext(UserContext);
   const [username: string, setUsername ] = useState('');
   const [roomId: string, setRoomId ] = useState('');
@@ -27,6 +29,7 @@ function JoinRoom(): React$Element<any> {
 
     socket.on('joined-room', (room: RoomT): void => {
       toast.success('Hey you joined!');
+      setRoom(room);
       setUser({ username, roomId: room.id, id: socket.id });
       history.push(`/room/${room.id}`);
     });

--- a/client/src/components/Room.js
+++ b/client/src/components/Room.js
@@ -1,6 +1,7 @@
 // @flow
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import SocketContext from 'contexts/SocketContext';
 import UserContext from 'contexts/UserContext';
 import { toast } from 'react-toastify';
 import Chat from 'components/Chat/Chat';

--- a/client/src/components/__mocks__/ElementWithProviders.js
+++ b/client/src/components/__mocks__/ElementWithProviders.js
@@ -1,23 +1,27 @@
 // @flow
 import React from 'react';
+import RoomContext from 'contexts/RoomContext';
 import SocketContext from 'contexts/SocketContext';
 import UserContext from 'contexts/UserContext';
-import type { UserT } from 'common/types';
+import type { RoomT, UserT } from 'common/types';
 import MockedProvider from 'providers/__mocks__/MockedProvider';
 
 type ElementWithProvidersT = {|
-  ui: React$Element<any>,
-  mockUserState: { user: ?UserT, setUser: mixed },
-  socket: Object,
+  children: React$Element<any>,
+  mockedRoomState?: ?{ room: ?RoomT, setRoom: (r: ?RoomT) => void },
+  mockedUserState?: ?{ user: ?UserT, setUser: (u: ?UserT) => void },
+  socket?: ?Object,
 |};
 
 function ElementWithProviders (
   props: ElementWithProvidersT
 ): React$Element<any> {
   return (
-    <MockedProvider value={props.mockUserState} context={UserContext}>
+    <MockedProvider value={props.mockedUserState} context={UserContext}>
       <MockedProvider value={props.socket} context={SocketContext}>
-        {props.ui}
+        <MockedProvider value={props.mockedRoomState} context={RoomContext}>
+          {props.children}
+        </MockedProvider>
       </MockedProvider>
     </MockedProvider>
   );

--- a/client/src/components/__mocks__/MockRouter.js
+++ b/client/src/components/__mocks__/MockRouter.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { MemoryRouter, Route, Router } from 'react-router-dom';
 
 type MockRouterT = {
-  ui: React$Element<any>,
+  children: React$Element<any>,
   initialEntries?: [string],
   path: string,
   history?: any,
@@ -14,7 +14,7 @@ function MockRouter(props: MockRouterT): React$Element<any>{
     return (
       <Router history={props.history}>
         <Route path={props.path}>
-          {props.ui}
+          {props.children}
         </Route>
       </Router>
     );
@@ -22,7 +22,7 @@ function MockRouter(props: MockRouterT): React$Element<any>{
   return (
     <MemoryRouter initialEntries={props.initialEntries}>
       <Route path={props.path}>
-        {props.ui}
+        {props.children}
       </Route>
     </MemoryRouter>
   );

--- a/client/src/components/__tests__/Chat/Chat.test.js
+++ b/client/src/components/__tests__/Chat/Chat.test.js
@@ -4,6 +4,7 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { test, expect, describe, afterEach, beforeEach } from '@jest/globals';
 import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
 import io, { serverSocket, cleanSocket } from 'utils/__mocks__/MockedSocketIO';
+import { user, setUser } from 'utils/__mocks__/mockedUserState';
 import Chat from 'components/Chat/Chat';
 
 import type { UserT, MessageT } from 'common/types';
@@ -11,20 +12,16 @@ import type { UserT, MessageT } from 'common/types';
 import '@testing-library/jest-dom';
 
 describe('Chat component', (): void => {
-
   const socket = io.connect();
-  let user: ?UserT = { username: 'user', id: 'id', roomId: 'roomid' };
   let ui: React$Element<any>;
 
-  const setUser = (newUser: ?UserT): void => { user = newUser; };
-
   beforeEach(() => {
+    const auxUser: ?UserT = { username: 'user', id: 'id', roomId: 'roomid' };
+    setUser(auxUser);
     ui = (
-      <ElementWithProviders 
-        ui={<Chat/>}
-        mockUserState={{ user, setUser }}
-        socket={socket}
-      />
+      <ElementWithProviders mockedUserState={{ user, setUser }} socket={socket}>
+        <Chat/>
+      </ElementWithProviders>
     );
   });
 

--- a/client/src/components/__tests__/CreateRoom.test.js
+++ b/client/src/components/__tests__/CreateRoom.test.js
@@ -16,36 +16,31 @@ import io, { serverSocket, cleanSocket } from 'utils/__mocks__/MockedSocketIO';
 import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
 import type { UserT, RoomT, CreateRoomRequestT } from 'common/types';
 import { ENTER_KEY_CODE } from 'utils/keycodes';
+import mockedRoomState from 'utils/__mocks__/mockedRoomState';
+import mockedUserState from 'utils/__mocks__/mockedUserState';
 
 import '@testing-library/jest-dom';
 
 describe('CreateRoom component', (): void => {
 
   const socket = io.connect();
-  let user: ?UserT;
   let history: any;
   let ui: React$Element<any>;
   let elementToRender: React$Element<any>;
 
-  const setUser = (newUser: ?UserT): void => { user = newUser; };
-
   beforeEach((): void => {
-    user = undefined;
     history = createMemoryHistory();
     history.push('/create');
-    ui = (
-      <MockRouter 
-        ui={<CreateRoom/>}
-        history={history}
-        path={'/create'}
-      />
-    );
     elementToRender = (
       <ElementWithProviders 
-        ui={ui}
-        mockUserState={{ user, setUser }}
+        mockedRoomState={mockedRoomState}
+        mockedUserState={mockedUserState}
         socket={socket}
-      />
+      >
+        <MockRouter history={history} path={'/create'}>
+          <CreateRoom/>
+        </MockRouter>
+      </ElementWithProviders>
     );
   });
 

--- a/client/src/components/__tests__/JoinRoom.test.js
+++ b/client/src/components/__tests__/JoinRoom.test.js
@@ -15,38 +15,33 @@ import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
 import MockRouter from 'components/__mocks__/MockRouter';
 import { createMemoryHistory } from 'history';
 import { ENTER_KEY_CODE } from 'utils/keycodes';
+import mockedRoomState from 'utils/__mocks__/mockedRoomState';
+import mockedUserState from 'utils/__mocks__/mockedUserState';
 
-import type { UserT, RoomT, JoinRoomRequestT } from 'common/types';
+import type { RoomT, JoinRoomRequestT } from 'common/types';
 
 import '@testing-library/jest-dom';
 
 describe('JoinRoom component', (): void => {
 
   const socket = io.connect();
-  let user: ?UserT;
   let history: any;
   let ui: React$Element<any>;
   let elementToRender: React$Element<any>;
 
-  const setUser: mixed = (user: UserT): void => { user = user; };
-
   beforeEach((): void => {
-    user = undefined;
     history = createMemoryHistory();
     history.push('/join');
-    ui = (
-      <MockRouter 
-        ui={<JoinRoom/>}
-        history={history}
-        path={'/join'}
-      />
-    );
     elementToRender = (
       <ElementWithProviders 
-        ui={ui}
-        mockUserState={{ user, setUser }}
+        mockedRoomState={mockedRoomState}
+        mockedUserState={mockedUserState}
         socket={socket}
-      />
+      >
+        <MockRouter history={history} path={'/join'}>
+          <JoinRoom/>
+        </MockRouter>
+      </ElementWithProviders>
     );
   });
 

--- a/client/src/components/__tests__/Room.test.js
+++ b/client/src/components/__tests__/Room.test.js
@@ -14,32 +14,17 @@ import io, { serverSocket, cleanSocket } from 'utils/__mocks__/MockedSocketIO';
 import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
 import MockRouter from 'components/__mocks__/MockRouter';
 import { createMemoryHistory } from 'history';
-import type { UserT, RoomT } from 'common/types';
+import { user, setUser } from 'utils/__mocks__/mockedUserState';
 import '@testing-library/jest-dom';
 
 
 describe('Room component', (): void => {
-
   const socket = io.connect();
-  let user: ?UserT;
-  let history: any;
-  let ui: React$Element<any>;
-
-  const setUser = (newUser: ?UserT): void => { user = newUser; };
-
   const roomId = '1234';
-
+  let history: any;
   beforeEach((): void => {
-    user = undefined;
     history = createMemoryHistory();
     history.push(`/room/${roomId}`);
-    ui = (
-      <MockRouter 
-        ui={<Room />}
-        history={history}
-        path={'/room/:id'}
-      />
-    );
   });
 
   afterEach(() => {
@@ -55,11 +40,11 @@ describe('Room component', (): void => {
     }
     setUser(fakeUser);
     render(
-      <ElementWithProviders 
-        ui={ui}
-        mockUserState={{ user, setUser }}
-        socket={socket}
-      />
+      <ElementWithProviders mockedUserState={{ user, setUser }} socket={socket}>
+        <MockRouter history={history} path={'/room/:id'}>
+          <Room />
+        </MockRouter>
+      </ElementWithProviders>
     );
     const re = new RegExp(`Room ${roomId}`);
     const search = screen.getByText(re);
@@ -69,11 +54,11 @@ describe('Room component', (): void => {
   test('If user is undefined, redirect to join to ask for it', (): void => {
     setUser(undefined);
     render(
-      <ElementWithProviders 
-        ui={ui}
-        mockUserState={{ user, setUser }}
-        socket={socket}
-      />
+      <ElementWithProviders mockedUserState={{ user, setUser }} socket={socket}>
+        <MockRouter history={history} path={'/room/:id'}>
+          <Room />
+        </MockRouter>
+      </ElementWithProviders>
     );
     expect(history.location.pathname).toBe(`/join/${roomId}`);
   });

--- a/client/src/components/__tests__/lobby/GetUserInLobby.test.js
+++ b/client/src/components/__tests__/lobby/GetUserInLobby.test.js
@@ -12,7 +12,7 @@ import {
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import io, { cleanSocket, serverSocket } from "utils/__mocks__/MockedSocketIO";
 import Lobby from "components/lobby/Lobby";
-import SocketContext from "contexts/SocketContext";
+import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
 import type {
   UserInLobbyT,
   ErrorCallBackT,
@@ -37,9 +37,9 @@ describe("When receive get-users-in-lobby request", () => {
       }
     );
     render(
-      <SocketContext.Provider value={socket}>
+      <ElementWithProviders socket={socket}>
         <Lobby />
-      </SocketContext.Provider>
+      </ElementWithProviders>
     );
     serverSocket.emit("get-users-in-lobby", (answer: Array<UserInLobbyT>) => {
       receivedUsers = answer;

--- a/client/src/components/__tests__/lobby/JoinLobby.test.js
+++ b/client/src/components/__tests__/lobby/JoinLobby.test.js
@@ -12,7 +12,7 @@ import {
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import io, { cleanSocket, serverSocket } from "utils/__mocks__/MockedSocketIO";
 import Lobby from "components/lobby/Lobby";
-import SocketContext from "contexts/SocketContext";
+import ElementWithProviders from "components/__mocks__/ElementWithProviders";
 
 describe("When user joins lobby", () => {
   const socket = io.connect();
@@ -26,9 +26,9 @@ describe("When user joins lobby", () => {
     });
     
     render(
-      <SocketContext.Provider value={socket}>
+      <ElementWithProviders socket={socket}>
         <Lobby />
-      </SocketContext.Provider>
+      </ElementWithProviders>
     );
   });
 

--- a/client/src/components/__tests__/lobby/ReadyForm.test.js
+++ b/client/src/components/__tests__/lobby/ReadyForm.test.js
@@ -27,11 +27,9 @@ describe('ReadyForm component', (): void => {
   beforeEach(() => {
     socket = io.connect();
     render(
-      <ElementWithProviders 
-        ui={<ReadyForm />}
-        mockUserState={{ user: null, setUser: null }}
-        socket={socket}
-      />
+      <ElementWithProviders socket={socket}>
+        <ReadyForm />
+      </ElementWithProviders>
     );
     readyButton = screen.getByRole('button', { name: /Ready/i });
     characterInput = screen.getByRole('textbox', {type: 'text'});

--- a/client/src/components/__tests__/lobby/ServerAnswersUsersInLobby.test.js
+++ b/client/src/components/__tests__/lobby/ServerAnswersUsersInLobby.test.js
@@ -12,7 +12,7 @@ import {
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import io, { cleanSocket, serverSocket } from "utils/__mocks__/MockedSocketIO";
 import Lobby from "components/lobby/Lobby";
-import SocketContext from "contexts/SocketContext";
+import ElementWithProviders from "components/__mocks__/ElementWithProviders";
 import type {
   UserInLobbyT,
   ErrorCallBackT,
@@ -41,9 +41,9 @@ describe("When server answers the users in lobby", () => {
         emittedUserJoined = true;
       });
       render(
-        <SocketContext.Provider value={socket}>
+        <ElementWithProviders socket={socket}>
           <Lobby />
-        </SocketContext.Provider>
+        </ElementWithProviders>
       );
     });
 

--- a/client/src/components/__tests__/lobby/UserIsReady.test.js
+++ b/client/src/components/__tests__/lobby/UserIsReady.test.js
@@ -18,7 +18,6 @@ import {
 import Lobby from 'components/lobby/Lobby';
 import io, { serverSocket, cleanSocket } from 'utils/__mocks__/MockedSocketIO';
 import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
-import SocketContext from 'contexts/SocketContext';
 import type { 
   UserT, 
   UserIsReadyT, 
@@ -64,9 +63,9 @@ describe('user is ready functionality', () => {
       }
     );
     render(
-      <SocketContext.Provider value={socket}>
+      <ElementWithProviders socket={socket}>
         <Lobby />
-      </SocketContext.Provider>
+      </ElementWithProviders>
     );
   });
   describe('the user is not ready yet', () => {

--- a/client/src/components/__tests__/lobby/UserJoins.test.js
+++ b/client/src/components/__tests__/lobby/UserJoins.test.js
@@ -12,7 +12,7 @@ import {
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import io, { cleanSocket, serverSocket } from "utils/__mocks__/MockedSocketIO";
 import Lobby from "components/lobby/Lobby";
-import SocketContext from "contexts/SocketContext";
+import ElementWithProviders from "components/__mocks__/ElementWithProviders";
 import type {
   UserInLobbyT,
   ErrorCallBackT,
@@ -37,9 +37,9 @@ describe("When user is in lobby and another user joins", () => {
         }
       );
       render(
-        <SocketContext.Provider value={socket}>
+        <ElementWithProviders socket={socket}>
           <Lobby />
-        </SocketContext.Provider>
+        </ElementWithProviders>
       );
       const username: string = "test-username";
       act(() => {

--- a/client/src/contexts/RoomContext.js
+++ b/client/src/contexts/RoomContext.js
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react';
+
+import type { RoomT } from 'common/types';
+
+export type RoomContextT = {
+  room: ?RoomT,
+  setRoom: (r: ?RoomT) => void,
+}
+
+const RoomContext: React$Context<RoomContextT> = 
+  React.createContext<RoomContextT>({
+    room: undefined,
+    setRoom: (r: ?RoomT): void => {},
+  });
+
+export default RoomContext;

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -1,6 +1,16 @@
 // @flow
 import React from 'react';
+import type { UserT } from 'common/types';
+ 
+export type UserContextT = {|
+  user: ?UserT,
+  setUser: (u: ?UserT) => void,
+|}
 
-const UserContext: React$Context<any> = React.createContext();
+const UserContext: React$Context<UserContextT> = 
+  React.createContext<UserContextT>({
+    user: undefined,
+    setUser: (u: ?UserT): void => {}
+  });
 
 export default UserContext;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
+import RoomProvider from 'providers/RoomProvider';
 import SocketProvider from 'providers/SocketProvider';
 import UserProvider from 'providers/UserProvider';
 import './index.css';
@@ -10,13 +11,15 @@ import reportWebVitals from './vitals/reportWebVitals';
 
 ReactDOM.render(
   <React.StrictMode>
-    <UserProvider>
-      <SocketProvider>
-        <Router>
-          <App />
-        </Router>
-      </SocketProvider>
-    </UserProvider>
+    <RoomProvider>
+      <UserProvider>
+        <SocketProvider>
+          <Router>
+            <App />
+          </Router>
+        </SocketProvider>
+      </UserProvider>
+    </RoomProvider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/client/src/providers/RoomProvider.js
+++ b/client/src/providers/RoomProvider.js
@@ -1,0 +1,16 @@
+// @flow
+import React, { useState } from 'react';
+import RoomContext from 'contexts/RoomContext';
+
+import type { RoomT } from 'common/types';
+
+const RoomProvider = ({ children }: any): React$Element<any> => {
+	const [room: ?RoomT, setRoom: (r: RoomT) => void ] = useState(undefined);
+	return (
+		<RoomContext.Provider value={{room, setRoom}}>
+			{children}
+		</RoomContext.Provider>
+	);
+}
+
+export default RoomProvider;

--- a/client/src/providers/UserProvider.js
+++ b/client/src/providers/UserProvider.js
@@ -5,12 +5,12 @@ import UserContext from 'contexts/UserContext';
 import type { UserT } from 'common/types';
 
 const UserProvider = ({ children }: any): React$Element<any> => {
-    const [user: UserT, setUser: mixed ] = useState();
-    return (
-        <UserContext.Provider value={{user, setUser}}>
-            {children}
-        </UserContext.Provider>
-    );
+	const [user: ?UserT, setUser: (u: UserT) => void ] = useState(undefined);
+	return (
+		<UserContext.Provider value={{ user, setUser }}>
+			{children}
+		</UserContext.Provider>
+	);
 }
 
 export default UserProvider;

--- a/client/src/utils/__mocks__/mockedRoomState.js
+++ b/client/src/utils/__mocks__/mockedRoomState.js
@@ -1,0 +1,9 @@
+// @flow
+import type { RoomT } from 'common/types';
+
+export let room: ?RoomT = undefined;
+export const setRoom = (r: ?RoomT): void => { room = r };
+
+const mockedRoomState = { room, setRoom}; 
+
+export default mockedRoomState;

--- a/client/src/utils/__mocks__/mockedUserState.js
+++ b/client/src/utils/__mocks__/mockedUserState.js
@@ -1,0 +1,9 @@
+// @flow
+import type { UserT } from 'common/types';
+
+export let user: ?UserT = undefined;
+export const setUser: (u: ?UserT) => void = (u: ?UserT): void => { user = u };
+
+const mockedUserState = { user, setUser };
+
+export default mockedUserState;


### PR DESCRIPTION
Let's use ElementWithProviders for future tests. If we add new providers and are needed in some tests, we need to change a lot of stuff. With this, we only need to provide the value for the providers, and we can mock them easily.