### PR TITLE
test owner changes

### DIFF
--- a/client/src/components/__tests__/Room.test.js
+++ b/client/src/components/__tests__/Room.test.js
@@ -15,16 +15,16 @@ import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
 import MockRouter from 'components/__mocks__/MockRouter';
 import { createMemoryHistory } from 'history';
 import { user, setUser } from 'utils/__mocks__/mockedUserState';
+import { ROOMID } from 'utils/__mocks__/mockedRoomState';
 import '@testing-library/jest-dom';
 
 
 describe('Room component', (): void => {
   const socket = io.connect();
-  const roomId = '1234';
   let history: any;
   beforeEach((): void => {
     history = createMemoryHistory();
-    history.push(`/room/${roomId}`);
+    history.push(`/room/${ROOMID}`);
   });
 
   afterEach(() => {
@@ -33,12 +33,6 @@ describe('Room component', (): void => {
   });
 
   test('Load room view if the user is defined', (): void => {
-    const fakeUser = {
-      id: 'mock-id',
-      username: 'mock-username',
-      roomId: 'mock-roomId',
-    }
-    setUser(fakeUser);
     render(
       <ElementWithProviders mockedUserState={{ user, setUser }} socket={socket}>
         <MockRouter history={history} path={'/room/:id'}>
@@ -46,7 +40,7 @@ describe('Room component', (): void => {
         </MockRouter>
       </ElementWithProviders>
     );
-    const re = new RegExp(`Room ${roomId}`);
+    const re = new RegExp(`Room ${ROOMID}`);
     const search = screen.getByText(re);
     expect(search).toBeInTheDocument();
   });
@@ -60,7 +54,7 @@ describe('Room component', (): void => {
         </MockRouter>
       </ElementWithProviders>
     );
-    expect(history.location.pathname).toBe(`/join/${roomId}`);
+    expect(history.location.pathname).toBe(`/join/${ROOMID}`);
   });
   
 });

--- a/client/src/components/__tests__/lobby/UserJoins.test.js
+++ b/client/src/components/__tests__/lobby/UserJoins.test.js
@@ -14,7 +14,7 @@ import io, { cleanSocket, serverSocket } from "utils/__mocks__/MockedSocketIO";
 import Room from "components/Room";
 import ElementWithProviders from "components/__mocks__/ElementWithProviders";
 import MockRouter from 'components/__mocks__/MockRouter';
-import {user, setUser} from 'utils/__mocks__/mockedUserState';
+import { ROOMID } from 'utils/__mocks__/mockedRoomState';
 import type {
   UserT,
   UserInLobbyT,
@@ -39,15 +39,9 @@ describe("When user is in lobby and another user joins", () => {
           succesCallback(mockUsers);
         }
       );
-      const fakeUser: UserT = {
-        id: 'id',
-        username: 'username',
-        roomId: '1234',
-      }
-      setUser(fakeUser);
       render(
-        <ElementWithProviders socket={socket} mockedUserState={{user, setUser}}>
-          <MockRouter initialEntries={['/room/1234']} path={'/room/:id'}>
+        <ElementWithProviders socket={socket}>
+          <MockRouter initialEntries={[`/room/${ROOMID}`]} path={'/room/:id'}>
             <Room />
           </MockRouter>
         </ElementWithProviders>

--- a/client/src/components/__tests__/lobby/UserLeaves.test.js
+++ b/client/src/components/__tests__/lobby/UserLeaves.test.js
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   cleanup,
+  queryByText,
   act,
 } from '@testing-library/react';
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
@@ -12,8 +13,9 @@ import io, { cleanSocket, serverSocket } from 'utils/__mocks__/MockedSocketIO';
 import MockRouter from 'components/__mocks__/MockRouter';
 import Room from 'components/Room';
 import ElementWithProviders from 'components/__mocks__/ElementWithProviders';
-import { user, setUser } from 'utils/__mocks__/mockedUserState';
+import { room, setRoom, ROOMID } from 'utils/__mocks__/mockedRoomState';
 import type {
+  RoomT,
   UserT,
   UserInLobbyT,
   ErrorCallBackT,
@@ -43,34 +45,75 @@ describe('When a user in lobby leaves', () => {
       serverSocket.on('leave-room', (errorCallback: ErrorCallBackT) => {
         serverSocket.emit('user-left', leaverUsername);
       });
-      const fakeUser: UserT = {
-        id: 'id',
-        username: 'username',
-        roomId: 'roomId',
-      }
-      setUser(fakeUser);
-      render(
-        <ElementWithProviders socket={socket} mockedUserState={{user, setUser}}>
-          <MockRouter initialEntries={['/room/1234']} path={'/room/:id'}>
-            <Room />
-          </MockRouter>
-        </ElementWithProviders>
-      );
-      act(() => {
-        socket.emit('leave-room');
-      });
     });
     afterEach(() => {
       cleanup();
       cleanSocket();
     });
-    test('Removes one item from the user list', () => {
-      const users = screen.getAllByRole('listitem');
-      expect(users.length).toBe(mockUsers.length - 1);
+    describe('When the leaver is a regular user', () => {
+      beforeEach(() => {
+        render(
+          <ElementWithProviders socket={socket}>
+            <MockRouter initialEntries={[`/room/${ROOMID}`]} path={'/room/:id'}>
+              <Room />
+            </MockRouter>
+          </ElementWithProviders>
+        );
+        act(() => {
+          socket.emit('leave-room');
+        });
+      });
+      test('Removes one item from the user list', () => {
+        const users = screen.getAllByRole('listitem');
+        expect(users.length).toBe(mockUsers.length - 1);
+      });
+      test('Does not includes the username', () => {
+        const userDiv = screen.queryByText(/test-leaver/);
+        expect(userDiv).toBeNull();
+      });
     });
-    test('Does not includes the username', () => {
-      const userDiv = screen.queryByText(/test-leaver/);
-      expect(userDiv).toBeNull();
+    describe('When the leaver is the owner', () => {
+      let mockedUsernames: Array<string>;
+      beforeEach(() => {
+        mockedUsernames = mockUsers.map((user: UserInLobbyT) => user.username);
+        let testRoom: RoomT = {
+          id: ROOMID,
+          owner: leaverUsername,
+          users: mockedUsernames,
+          round: 0,
+          time: 30,
+        };
+        setRoom(testRoom);
+        serverSocket.on('leave-room', (errorCallback: ErrorCallBackT) => {
+          if(room) {
+            const newOwner: string = room.users[0];
+            testRoom.owner = newOwner;
+            setRoom(testRoom);
+            serverSocket.emit('room-owner-changed', newOwner);
+          }
+          else return errorCallback({ error: 'room not found'});
+        });
+        render(
+          <ElementWithProviders 
+            socket={socket} 
+            mockedRoomState={{room, setRoom}}
+          >
+            <MockRouter initialEntries={[`/room/${ROOMID}`]} path={'/room/:id'}>
+              <Room />
+            </MockRouter>
+          </ElementWithProviders>
+        );
+        act(() => {
+          socket.emit('leave-room');
+        });
+      });
+      test('the owner should change to the next one in the list', () => {
+        const newOwnerRegex = new RegExp(mockedUsernames[0]);
+        const ownerDiv = screen.getByText(newOwnerRegex);
+        const ownerStar = queryByText(ownerDiv, /⭐/);
+        expect(room?.owner).toBe(mockedUsernames[0]);
+        expect(ownerStar).not.toBeNull();
+      });
     });
   });
 });

--- a/client/src/utils/__mocks__/mockedRoomState.js
+++ b/client/src/utils/__mocks__/mockedRoomState.js
@@ -1,7 +1,16 @@
 // @flow
+import { USERNAME } from './mockedUserState'; 
 import type { RoomT } from 'common/types';
 
-export let room: ?RoomT = undefined;
+export const ROOMID = 'roomId';
+
+export let room: ?RoomT = {
+  id: ROOMID,
+  owner: USERNAME,
+  users: [USERNAME],
+  round: 0,
+  time: 30,
+};
 export const setRoom = (r: ?RoomT): void => { room = r };
 
 const mockedRoomState = { room, setRoom}; 

--- a/client/src/utils/__mocks__/mockedUserState.js
+++ b/client/src/utils/__mocks__/mockedUserState.js
@@ -1,7 +1,15 @@
 // @flow
+import { ROOMID } from './mockedRoomState'; 
 import type { UserT } from 'common/types';
 
-export let user: ?UserT = undefined;
+export const USERNAME: string = 'mock-username';
+export const USERID: string = 'user-id';
+
+export let user: ?UserT = {
+  id: USERID,
+  username: USERNAME,
+  roomId: ROOMID,
+};
 export const setUser: (u: ?UserT) => void = (u: ?UserT): void => { user = u };
 
 const mockedUserState = { user, setUser };


### PR DESCRIPTION
Continuation of #90 
The logic of changing the owner is in the last pr, here we just test it and add the default value for user and room when testing, to have cleaner tests and avoid repeating code. 
Test when the user leaves and it's the room owner.
User 'a' is the owner
![Screenshot 2021-05-04 13:48:38](https://user-images.githubusercontent.com/40135286/117054525-cc49b880-acdf-11eb-8c89-b40cfad57a25.png)
User 'a' leaves, the rest of the room gets the new owner
![2](https://user-images.githubusercontent.com/40135286/117054529-cd7ae580-acdf-11eb-974e-82610b9a5b7e.png)
